### PR TITLE
Phase 3 password is truncated in the walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Useful OpenSSL flags:
 * Brute force is used to find part 5 being "11110", the real path/reasoning hasn't been discovered or disclosed.
 * Part 6 is a reference to the Genesis Block of bitcoin, and directly to a particular line in the source code leading to "0x736B6E616220726F662074756F6C69616220646E6F63657320666F206B6E697262206E6F20726F6C6C65636E61684320393030322F6E614A2F33302073656D695420656854" as part 6
 * Part 7 is a chess puzzle where a white piece must be moved without causing check-mate. The final solution is "B5KR/1r5B/2R5/2b1p1p1/2P1k1P1/1p2P2p/1P2P2P/3N1N2 b - - 0 1"
-* Putting everything together with the case hints and white space hints we get the final password as "causalitySafenetLunaHSM111100x736B6E616220726F662074756F6C69616220646E6F63657320666F206B6E697262206E6F20726F6C6C65636E61684320393030322F6E614A2F33302073656D695420656854B5KR"
+* Putting everything together with the case hints and white space hints we get the final password as "causalitySafenetLunaHSM111100x736B6E616220726F662074756F6C69616220646E6F63657320666F206B6E697262206E6F20726F6C6C65636E61684320393030322F6E614A2F33302073656D695420656854B5KR/1r5B/2R5/2b1p1p1/2P1k1P1/1p2P2p/1P2P2P/3N1N2 b - - 0 1"
 * sha256 of that password is the key to decrypting phase 3
 
 


### PR DESCRIPTION
I hit a wall following the phase 2.2 section and it turned out to be the password, not me. The diff is
just that one line. Two hint notes at the end that you're welcome to fold in or ignore, I didn't want
to touch more of the walkthrough than needed.

## Phase 3 password

Phase 2.2 gives the assembled password as ending in `B5KR`. That does not decrypt phase 3. The FEN
goes in whole, not just the first field:

    causalitySafenetLunaHSM111100x736B6E616220726F662074756F6C69616220646E6F63657320666F206B6E697262206E6F20726F6C6C65636E61684320393030322F6E614A2F33302073656D695420656854B5KR/1r5B/2R5/2b1p1p1/2P1k1P1/1p2P2p/1P2P2P/3N1N2 b - - 0 1

Slashes, spaces and the trailing `b - - 0 1` included. sha256 of that is

    1a57c572caf3cf722e41f5f9cf99ffacff06728a43032dd44c481c77d2ec30d5

and phase 3 then decrypts to the text starting "What if the merovingian is wrong."

The encryption takes that digest as the passphrase rather than the password itself, same as phase 2,
so:

    openssl enc -d -aes-256-cbc -a -md sha256 \
      -pass pass:1a57c572caf3cf722e41f5f9cf99ffacff06728a43032dd44c481c77d2ec30d5 \
      -in phase3.txt

Line 108 above it already has the full FEN, so it looks like it just got clipped when the parts were
assembled on line 109. Following the README as written you get garbage with no clue why.

## 2021-03-01, "fefefe is 101 010"

The README lists this one as unsolved. It is the hex digits read as odd or even. F is 15, odd, so 1.
E is 14, even, so 0. FEFEFE gives 101010, which is 42.

Same rule on the other two colours: `#FFF200` gives 111000, `#3F48CC` gives 110000.

## 2020-01-14, "Yellow has a number and so does Blue"

The numbers look like 9 and 15, and they match something already known.

Sampling puzzle.png on the 14x14 grid I get 9 yellow cells and 15 blue. Taking the counter-clockwise
spiral used in phase 0 and numbering from 0, all 24 of those cells land on indices congruent to
7 mod 8, which is the last bit of each byte. Reading blue as 1 and yellow as 0 along those 24
positions:

    111101110011110110010010

and the low bit of each character of `gsmg.io/theseedisplanted`:

    111101110011110110010010

Same string, and the 15 blue cells line up with the 15 one bits, the 9 yellow with the 9 zero bits.

So the counts match the URL's low bits under this reading. I don't think they give a new input to
`yellowblueprimes`, though obviously that only rules out this interpretation. Noting it in case it
saves someone repeating it.

The two hint sections are just notes, no diff for them. Say the word if you want them written into
the timeline and I'll send a second PR.