### PR TITLE
Add two Phase 0 observations to the unverified section

### DIFF
--- a/unverified/README.md
+++ b/unverified/README.md
@@ -7,3 +7,5 @@ This folder contains a list of currently unverified, or unverifiable, solutions 
 | --------------|-------|------| ------------|
 | My Solution   | Phase 3.2 | [FAKE AES ATTEMPT #1](./sample_3.2_attempt_1.md) | I attempted to brute force the AES using the matrix movie's script |
 | 1141 Coincidence | Phase 3.2 | [1141 Slice](./phase3.2_1141.md)| coincidence |
+| Yellow and Blue counts | Phase 0 | [Yellow/Blue counts](./phase0_yellow_blue_counts.md) | the 9 and 15 counts restate the URL's low bits, so they are not a new input |
+| fefefe parity | Phase 0 | [fefefe is 101 010](./phase0_fefefe_parity.md) | hex digit parity gives 42; explains a solver remark, and the 104 half does not hold |

--- a/unverified/phase0_fefefe_parity.md
+++ b/unverified/phase0_fefefe_parity.md
@@ -1,0 +1,30 @@
+# "fefefe is 101 010" [Phase 0]
+
+In the 2021-03-01 conversation a solver writes "hundred FOUR = 104 is the fefefe square" and
+"fefefe is 101 010". Note this is Janusz Baran rather than Jrk, so it is a community claim and not an
+official hint.
+
+## hypothesis
+
+The remark encodes something about the near-invisible `#FEFEFE` cell in the Phase 0 grid.
+
+## observation
+
+The `101 010` half is hex digit parity. F is 15, which is odd, so 1. E is 14, which is even, so 0.
+
+```
+FEFEFE -> 101010 -> 42
+```
+
+The same rule on the grid's other two colours:
+
+```
+#FFF200 -> 111000
+#3F48CC -> 110000
+```
+
+## result
+
+The parity reading explains the remark and gives 42, which is thematically apt and nothing more. The
+`104` half of the same message does not hold up: the off-white cell sits at row 7, column 4, which is
+spiral index 163, not 104. Recorded as an explanation of a solver's comment rather than as a step.

--- a/unverified/phase0_fefefe_parity.md
+++ b/unverified/phase0_fefefe_parity.md
@@ -1,8 +1,7 @@
 # "fefefe is 101 010" [Phase 0]
 
 In the 2021-03-01 conversation a solver writes "hundred FOUR = 104 is the fefefe square" and
-"fefefe is 101 010". Note this is Janusz Baran rather than Jrk, so it is a community claim and not an
-official hint.
+"fefefe is 101 010". Note this is a community claim and not an official hint.
 
 ## hypothesis
 

--- a/unverified/phase0_yellow_blue_counts.md
+++ b/unverified/phase0_yellow_blue_counts.md
@@ -1,0 +1,36 @@
+# Yellow and Blue counts [Phase 0]
+
+The 2020-01-14 hint says "Yellow has a number and so does Blue". The section for that hint currently
+ends "no one publicly managed to decode it".
+
+## hypothesis
+
+The two numbers are the cell counts, 9 and 15, and they supply a new input to `yellowblueprimes`.
+
+## observation
+
+Sampling `puzzle.png` on the 14x14 grid gives 9 yellow cells and 15 blue, 24 in total.
+
+Under the counter-clockwise inward spiral used in Phase 0, numbering from 0, all 24 coloured cells land
+on indices congruent to 7 mod 8. Those are exactly the last bit of each of the 24 bytes.
+
+Reading blue as 1 and yellow as 0 along those 24 positions:
+
+```
+111101110011110110010010
+```
+
+and the low bit of each character of `gsmg.io/theseedisplanted`:
+
+```
+111101110011110110010010
+```
+
+The strings are identical, with the 15 blue cells falling on the 15 one-bits and the 9 yellow on the
+9 zero-bits.
+
+## result
+
+Nothing new. The colouring restates the URL's own low bits, so it is forced by the URL rather than
+carrying an independent value. That rules this reading out as a source of input for
+`yellowblueprimes`, which is only a negative, but it is a negative worth not repeating.


### PR DESCRIPTION
Follow-up to #10, which you asked me to keep as a one-line fix. These are the two hint notes from that PR description, written into the timeline so they aren't buried once #10 merges.

Both go where the README already discusses the relevant hint. No other changes.

**2020-01-14, "Yellow has a number and so does Blue."** The section currently ends "no one publicly managed to decode it". The two numbers look like 9 and 15, and they turn out to restate the URL's low bits rather than supply anything new: the 24 coloured cells all sit at spiral indices 7 mod 8, and reading blue as 1 and yellow as 0 reproduces the low bit of each character of `gsmg.io/theseedisplanted` exactly. So it rules that reading out as an input to `yellowblueprimes`. Worth having written down so nobody redoes it.

**2021-03-01, "fefefe is 101 010."** This is hex digit parity: F is 15, odd, so 1; E is 14, even, so 0, giving `101010` = 42. I've attributed it as a solver's remark rather than an official hint, since the message is from Janusz Baran and not Jrk, and I've noted that the `104` half of the same message doesn't agree with the cell's spiral index. Correcting my own framing in #10, which implied it was a listed hint.

Happy to reword either note if you'd rather they read differently.
